### PR TITLE
update ubus

### DIFF
--- a/libubus-io.c
+++ b/libubus-io.c
@@ -328,8 +328,10 @@ void __hidden ubus_handle_data(struct uloop_fd *u, unsigned int events)
 	if (!ctx->stack_depth)
 		ctx->pending_timer.cb(&ctx->pending_timer);
 
-	if (u->eof)
+	if (u->eof) {
+		ubus_flush_requests(ctx);
 		ctx->connection_lost(ctx);
+	}
 }
 
 void __hidden ubus_poll_data(struct ubus_context *ctx, int timeout)

--- a/libubus-req.c
+++ b/libubus-req.c
@@ -137,6 +137,16 @@ static int64_t get_time_msec(void)
 	return val;
 }
 
+void ubus_flush_requests(struct ubus_context *ctx)
+{
+	struct ubus_request *req;
+
+	while (!list_empty(&ctx->requests)) {
+		req = list_first_entry(&ctx->requests, struct ubus_request, list);
+		ubus_set_req_status(req, UBUS_STATUS_TIMEOUT);
+	}
+}
+
 int ubus_complete_request(struct ubus_context *ctx, struct ubus_request *req,
 			  int req_timeout)
 {

--- a/libubus.h
+++ b/libubus.h
@@ -264,6 +264,7 @@ int ubus_channel_connect(struct ubus_context *ctx, int fd,
 			 ubus_handler_t handler);
 int ubus_channel_create(struct ubus_context *ctx, int *remote_fd,
 			ubus_handler_t handler);
+void ubus_flush_requests(struct ubus_context *ctx);
 
 static inline bool
 ubus_context_is_channel(struct ubus_context *ctx)

--- a/package/debian.changelog
+++ b/package/debian.changelog
@@ -1,3 +1,16 @@
+ubus (20250807) unstable; urgency=medium
+
+  Sync upstream
+  * ubusd: do not call socket callback from ubus_msg_send
+  * ubusd: add another tx attempt on enqueueing the first message for a client
+  * ubusd: fix txq_len accounting
+  * ubusd: retry write on EINTR
+  * ubusd: treat EACCES on write like EAGAIN
+  * ubusd: make txq_len field signed
+  * libubus: flush all pending requests on connection loss
+
+ -- Elektrobit  <info@elektrobit.com>  Thu, 07 Aug 2025 08:00:00 +0200
+
 ubus (20250206) unstable; urgency=medium
 
   * Bump Version

--- a/package/debian.ubus.dsc
+++ b/package/debian.ubus.dsc
@@ -2,9 +2,9 @@ Format: 3.0 (native)
 Source: ubus
 Binary: ubus, libubus1, libubus-dev
 Architecture: any
-Version: 20250206
+Version: 20250807
 Maintainer: Elektrobit <info@elektrobit.de>
 Standards-Version: 4.5.0
 Build-Depends: cmake, debhelper (>= 9), libubox-dev, libjson-c-dev
 Files:
- beadae62cdad594aea47f52c39beaf81 47295 ubus_20250206.tar.gz
+ 00000000000000000000000000000000 0 ubus_20250807.tar.gz

--- a/ubusd.c
+++ b/ubusd.c
@@ -144,7 +144,7 @@ static void ubus_msg_enqueue(struct ubus_client *cl, struct ubus_msg_buf *ub)
 {
 	struct ubus_msg_buf_list *ubl;
 
-	if (cl->txq_len + ub->len > UBUS_CLIENT_MAX_TXQ_LEN)
+	if (cl->txq_len + sizeof(ub->hdr) + ub->len > UBUS_CLIENT_MAX_TXQ_LEN)
 		return;
 
 	ubl = calloc(1, sizeof(struct ubus_msg_buf_list));
@@ -155,7 +155,7 @@ static void ubus_msg_enqueue(struct ubus_client *cl, struct ubus_msg_buf *ub)
 	ubl->msg = ubus_msg_ref(ub);
 
 	list_add_tail(&ubl->list, &cl->tx_queue);
-	cl->txq_len += ub->len;
+	cl->txq_len += ub->len + sizeof(ub->hdr);
 }
 
 /* takes the msgbuf reference */
@@ -181,5 +181,6 @@ void ubus_msg_send(struct ubus_client *cl, struct ubus_msg_buf *ub)
 		/* get an event once we can write to the socket again */
 		uloop_fd_add(&cl->sock, ULOOP_READ | ULOOP_WRITE | ULOOP_EDGE_TRIGGER);
 	}
+
 	ubus_msg_enqueue(cl, ub);
 }

--- a/ubusd.h
+++ b/ubusd.h
@@ -62,7 +62,7 @@ struct ubus_client {
 	struct list_head cmd_queue;
 	struct list_head tx_queue;
 	unsigned int txq_ofs;
-	unsigned int txq_len;
+	ssize_t txq_len;
 
 	struct ubus_msg_buf *pending_msg;
 	struct ubus_msg_buf *retmsg;


### PR DESCRIPTION
apply changes from 88e6325092bf1d1cfa877cd220670fa7cc2fad03 to 5952b48e251c0ea76dfce97f129da6f18d889eda from the upstream

Summary:
- ubusd: do not call socket callback from ubus_msg_send
- ubusd: add another tx attempt on enqueueing the first message for a client
- ubusd: fix txq_len accounting
- ubusd: retry write on EINTR
- ubusd: treat EACCES on write like EAGAIN
- ubusd: make txq_len field signed
- libubus: flush all pending requests on connection loss